### PR TITLE
chore: publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/cubbyjs",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "index.js",
   "repository": "https://github.com/rentpath/cubbyjs",
   "author": "RentPath",


### PR DESCRIPTION
[CARD](https://rentpath.atlassian.net/browse/DX-796)
We'll try the publish workflow again now: `lerna` objected to tags leftover from development last time. I've since deleted those and made a change to the version inside the main package.json in order to create this branch. `lerna` will bump the versions of the actual packages automatically.