### PR TITLE
explicit error return from useRemoteStore hook, useUnwrap, fix mocks

### DIFF
--- a/packages/cubbyjs-preact/src/remoteStore.ts
+++ b/packages/cubbyjs-preact/src/remoteStore.ts
@@ -3,4 +3,7 @@ import { createStore } from './store'
 import { useRef, useCallback } from 'preact/hooks'
 
 export { RemoteStore, RemoteStoreConfig } from '@rentpath/cubbyjs-common'
-export const createRemoteStore = initRemoteStore(createStore, useCallback, useRef)
+const remoteStore = initRemoteStore(createStore, useCallback, useRef)
+
+export const createRemoteStore = remoteStore.createRemoteStore
+export const useUnwrap = remoteStore.useUnwrap

--- a/packages/cubbyjs-react/src/remoteStore.ts
+++ b/packages/cubbyjs-react/src/remoteStore.ts
@@ -3,4 +3,7 @@ import { createStore } from './store'
 import * as React from 'react'
 
 export { RemoteStore, RemoteStoreConfig } from '@rentpath/cubbyjs-common'
-export const createRemoteStore = initRemoteStore(createStore, React.useCallback, React.useRef)
+const remoteStore = initRemoteStore(createStore, React.useCallback, React.useRef)
+
+export const createRemoteStore = remoteStore.createRemoteStore
+export const useUnwrap = remoteStore.useUnwrap


### PR DESCRIPTION
* explicitly return errors from `useRemoteStore`
* add a new hook, `useUnwrap`, which takes a `useRemoteStore` result and throws the error if present and not changed since last render
* make `remoteStore` mocks not overwrite the contents of the store every time they are called, so that multiple cache states can be mocked at the same time
* make the `remoteStore` mocks take an optional `fetching` argument that sets the `fetching` property for that mocked cache state